### PR TITLE
Use static linking

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,11 @@
+[target.x86_64-unknown-linux-gnu]
+linker="x86_64-linux-gnu-gcc"
+
+[target.x86_64-unknown-linux-musl]
+linker="x86_64-linux-gnu-gcc"
+
+[target.aarch64-unknown-linux-musl]
+linker="aarch64-linux-gnu-gcc"
+
+[target.aarch64-unknown-linux-gnu]
+linker="aarch64-linux-gnu-gcc"

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,13 +2,10 @@
 
 FROM mcr.microsoft.com/vscode/devcontainers/rust:1-1-bookworm
 
-RUN dpkg --add-architecture arm64 && \
-    apt-get update && export DEBIAN_FRONTEND=noninteractive \
+RUN apt update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get -y install --no-install-recommends \
     tmux \
-    vim \
-    gcc-aarch64-linux-gnu \
-    libssl-dev:arm64 \
-    libc6-dev:arm64
+    vim 
 
-RUN rustup target add aarch64-unknown-linux-gnu
+RUN rustup target add x86_64-unknown-linux-musl \
+    && rustup target add aarch64-unknown-linux-musl

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@ target
 temp
 docker-compose.yml
 .devcontainer/*.env
-.cargo
+.cargo/*
+!.cargo/config.toml

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -1,5 +1,5 @@
 variables:
-  - &rust 'rust:1.77.1-bookworm'
+  - &rust 'rust:1.79-bookworm'
   - &buildx_plugin 'woodpeckerci/plugin-docker-buildx:2.1.0'
 
 labels:
@@ -7,7 +7,7 @@ labels:
 
 clone:
   git:
-    image: woodpeckerci/plugin-git:2.2.0
+    image: woodpeckerci/plugin-git:2.5.1
     when:
       - event: pull_request
       - event: [push, tag, manual]

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -3,7 +3,7 @@ variables:
   - &buildx_plugin 'woodpeckerci/plugin-docker-buildx:2.1.0'
 
 labels:
-  platform: linux/amd64
+  platform: linux/arm64
 
 clone:
   git:
@@ -14,41 +14,32 @@ clone:
         branch: main
 
 steps:
-  - name: build-x86
+  - name: build-arm64
     image: *rust
-    commands: |
-      if [ "$CI_SYSTEM_PLATFORM" = "linux/amd64" ]; then  
-        export CARGO_HOME=$(pwd)/.cargo/
-        cargo test
-        cargo build --release
-        mkdir -p target/linux/amd64
-        cp target/release/picus target/linux/amd64/picus
-      else
-        echo Unsupported platform!
-        exit1
-      fi
+    commands:
+      - apt update
+      - apt install -y musl-tools
+      - rustup target add aarch64-unknown-linux-musl
+      - export CARGO_HOME=$(pwd)/.cargo/
+      - cargo test --target aarch64-unknown-linux-musl
+      - cargo build --release --target aarch64-unknown-linux-musl
+      - mkdir -p target/linux/arm64
+      - cp target/aarch64-unknown-linux-musl/release/picus target/linux/arm64/
     when:
       - event: pull_request
       - event: [push, tag, manual]
         branch: main
 
-  - name: build-arm64
+  - name: build-x86
     image: *rust
-    commands: |
-      if [ "$CI_SYSTEM_PLATFORM" = "linux/amd64" ]; then  
-        dpkg --add-architecture arm64
-        apt-get update
-        export DEBIAN_FRONTED=noninteractive
-        apt-get -y install --no-install-recommends gcc-aarch64-linux-gnu libssl-dev:arm64 libc6-dev:arm64
-        rustup target add aarch64-unknown-linux-gnu
-        export CARGO_HOME=$(pwd)/.cargo/
-        RUSTFLAGS="-C linker=aarch64-linux-gnu-gcc" PKG_CONFIG_SYSROOT_DIR=/ cargo build --target aarch64-unknown-linux-gnu --release
-        mkdir -p target/linux/arm64
-        cp target/aarch64-unknown-linux-gnu/release/picus target/linux/arm64/
-      else
-        echo Unsupported platform!
-        exit1
-      fi
+    commands:
+      - apt update
+      - apt install -y gcc-x86-64-linux-gnu musl-tools
+      - rustup target add x86_64-unknown-linux-musl
+      - export CARGO_HOME=$(pwd)/.cargo/
+      - cargo build --release --target x86_64-unknown-linux-musl
+      - mkdir -p target/linux/amd64
+      - cp target/x86_64-unknown-linux-musl/release/picus target/linux/amd64/picus
     when:
       - event: pull_request
       - event: [push, tag, manual]

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -23,8 +23,7 @@ steps:
       - export CARGO_HOME=$(pwd)/.cargo/
       - cargo test --target aarch64-unknown-linux-musl
       - cargo build --release --target aarch64-unknown-linux-musl
-      - mkdir -p target/linux/arm64
-      - cp target/aarch64-unknown-linux-musl/release/picus target/linux/arm64/
+      - cp target/aarch64-unknown-linux-musl/release/picus target/picus-linux-arm64
     when:
       - event: pull_request
       - event: [push, tag, manual]
@@ -38,8 +37,7 @@ steps:
       - rustup target add x86_64-unknown-linux-musl
       - export CARGO_HOME=$(pwd)/.cargo/
       - cargo build --release --target x86_64-unknown-linux-musl
-      - mkdir -p target/linux/amd64
-      - cp target/x86_64-unknown-linux-musl/release/picus target/linux/amd64/picus
+      - cp target/x86_64-unknown-linux-musl/release/picus target/picus-linux-amd64
     when:
       - event: pull_request
       - event: [push, tag, manual]

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -55,6 +55,7 @@ steps:
         branch: main
 
   - name: publish-distroless
+    depends_on: [build-arm64, build-x86, check-licenses]
     image: *buildx_plugin
     settings:
       platforms: linux/amd64,linux/arm64
@@ -79,6 +80,7 @@ steps:
       branch: main
 
   - name: publish-debian
+    depends_on: [build-arm64, build-x86, check-licenses]
     image: *buildx_plugin
     settings:
       platforms: linux/amd64,linux/arm64

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -3,7 +3,7 @@ variables:
   - &buildx_plugin 'woodpeckerci/plugin-docker-buildx:2.1.0'
 
 labels:
-  platform: linux/arm64
+  platform: linux/amd64
 
 clone:
   git:
@@ -14,30 +14,14 @@ clone:
         branch: main
 
 steps:
-  - name: build-arm64
-    depends_on: []
+  - name: build-x86
     image: *rust
     commands:
       - apt update
       - apt install -y musl-tools
-      - rustup target add aarch64-unknown-linux-musl
-      - export CARGO_HOME=$(pwd)/.cargo/
-      - cargo test --target aarch64-unknown-linux-musl
-      - cargo build --release --target aarch64-unknown-linux-musl
-      - cp target/aarch64-unknown-linux-musl/release/picus target/picus-linux-arm64
-    when:
-      - event: pull_request
-      - event: [push, tag, manual]
-        branch: main
-
-  - name: build-x86
-    depends_on: []
-    image: *rust
-    commands:
-      - apt update
-      - apt install -y gcc-x86-64-linux-gnu musl-tools
       - rustup target add x86_64-unknown-linux-musl
       - export CARGO_HOME=$(pwd)/.cargo/
+      - cargo test --target x86_64-unknown-linux-musl
       - cargo build --release --target x86_64-unknown-linux-musl
       - cp target/x86_64-unknown-linux-musl/release/picus target/picus-linux-amd64
     when:
@@ -45,8 +29,22 @@ steps:
       - event: [push, tag, manual]
         branch: main
 
+  - name: build-arm64
+    image: *rust
+    commands:
+      - dpkg --add-architecture arm64
+      - apt update
+      - apt install -y --no-install-recommends gcc-aarch64-linux-gnu musl-tools libc6-dev:arm64
+      - rustup target add aarch64-unknown-linux-musl
+      - export CARGO_HOME=$(pwd)/.cargo/
+      - cargo build --release --target aarch64-unknown-linux-musl
+      - cp target/aarch64-unknown-linux-musl/release/picus target/picus-linux-arm64
+    when:
+      - event: pull_request
+      - event: [push, tag, manual]
+        branch: main
+
   - name: check-licenses
-    depends_on: []
     image: *rust
     commands: 
       - export CARGO_HOME=$(pwd)/.cargo/
@@ -58,7 +56,6 @@ steps:
         branch: main
 
   - name: publish-distroless
-    depends_on: [build-arm64, build-x86, check-licenses]
     image: *buildx_plugin
     settings:
       platforms: linux/amd64,linux/arm64
@@ -83,7 +80,6 @@ steps:
       branch: main
 
   - name: publish-debian
-    depends_on: [build-arm64, build-x86, check-licenses]
     image: *buildx_plugin
     settings:
       platforms: linux/amd64,linux/arm64

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -15,6 +15,7 @@ clone:
 
 steps:
   - name: build-arm64
+    depends_on: []
     image: *rust
     commands:
       - apt update
@@ -30,6 +31,7 @@ steps:
         branch: main
 
   - name: build-x86
+    depends_on: []
     image: *rust
     commands:
       - apt update
@@ -44,6 +46,7 @@ steps:
         branch: main
 
   - name: check-licenses
+    depends_on: []
     image: *rust
     commands: 
       - export CARGO_HOME=$(pwd)/.cargo/

--- a/Dockerfile.distroless.multiarch
+++ b/Dockerfile.distroless.multiarch
@@ -1,8 +1,8 @@
-FROM gcr.io/distroless/cc-debian12:nonroot
+FROM gcr.io/distroless/static-debian12:nonroot
 
 LABEL org.opencontainers.image.source https://github.com/windsource/picus
 
 ARG TARGETOS TARGETARCH
-COPY target/${TARGETOS}/${TARGETARCH}/picus /usr/local/bin/picus
+COPY target/picus-${TARGETOS}-${TARGETARCH} /usr/local/bin/picus
 
 CMD ["/usr/local/bin/picus"]

--- a/Dockerfile.multiarch
+++ b/Dockerfile.multiarch
@@ -1,4 +1,4 @@
-FROM debian:12.1-slim
+FROM debian:12.6-slim
 
 LABEL org.opencontainers.image.source https://github.com/windsource/picus
 
@@ -9,6 +9,6 @@ RUN groupadd -g 999 appuser && \
 USER appuser
 
 ARG TARGETOS TARGETARCH
-COPY target/${TARGETOS}/${TARGETARCH}/picus /usr/local/bin/picus
+COPY target/picus-${TARGETOS}-${TARGETARCH} /usr/local/bin/picus
 
 CMD ["/usr/local/bin/picus"]


### PR DESCRIPTION
In order to provide picus binaries that can be used with all Linux distirbution, this PR chnages to statically linked binaries for all platform using musl. Also the CI build is using arm64 platforms as those are faster and cheaper (Hetzner cloud).