### PR TITLE
Use Makefile and publish artifacts

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,11 +1,19 @@
-# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.245.0/containers/rust/.devcontainer/base.Dockerfile
+# This dev container is supposed to work on amd64 and arm64 platform and
+# contains all tools to build for both platform
 
 FROM mcr.microsoft.com/vscode/devcontainers/rust:1-1-bookworm
 
-RUN apt update && export DEBIAN_FRONTEND=noninteractive \
-    && apt-get -y install --no-install-recommends \
-    tmux \
-    vim 
+ARG BUILDARCH
+
+RUN if [ "$BUILDARCH" = "amd64" ]; then \
+        dpkg --add-architecture arm64 && \
+        apt update && \
+        apt install -y gcc-aarch64-linux-gnu musl-tools libc6-dev:arm64; \
+    elif [ "$BUILDARCH" = "arm64" ]; then \
+        apt update && \
+        apt install -y gcc-x86-64-linux-gnu musl-tools; \
+    fi \
+    && apt install -y --no-install-recommends tmux vim 
 
 RUN rustup target add x86_64-unknown-linux-musl \
     && rustup target add aarch64-unknown-linux-musl

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ docker-compose.yml
 .devcontainer/*.env
 .cargo/*
 !.cargo/config.toml
+vendor
+dist

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "[makefile]": {
+        "editor.insertSpaces": false,
+        "editor.detectIndentation": false,
+        "editor.tabSize": 4
+    }  
+}

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -14,17 +14,21 @@ clone:
         branch: main
 
 steps:
+  - name: vendor
+    image: *rust
+    commands:
+      - make vendor
+    when:
+      - event: tag
+
   - name: build-x86
     image: *rust
     commands:
       - apt update
       - apt install -y musl-tools
       - rustup target add x86_64-unknown-linux-musl
-      - export CARGO_HOME=$(pwd)/.cargo/
-      - cargo test --target x86_64-unknown-linux-musl
-      - cargo build --release --target x86_64-unknown-linux-musl
-      - mkdir -p target/dist
-      - cp target/x86_64-unknown-linux-musl/release/picus target/dist/picus-linux-amd64
+      - make test
+      - make build-amd64
     when:
       - event: pull_request
       - event: [push, tag, manual]
@@ -37,10 +41,7 @@ steps:
       - apt update
       - apt install -y --no-install-recommends gcc-aarch64-linux-gnu musl-tools libc6-dev:arm64
       - rustup target add aarch64-unknown-linux-musl
-      - export CARGO_HOME=$(pwd)/.cargo/
-      - cargo build --release --target aarch64-unknown-linux-musl
-      - mkdir -p target/dist
-      - cp target/aarch64-unknown-linux-musl/release/picus target/dist/picus-linux-arm64
+      - make build-arm64
     when:
       - event: pull_request
       - event: [push, tag, manual]
@@ -49,13 +50,18 @@ steps:
   - name: check-licenses
     image: *rust
     commands: 
-      - export CARGO_HOME=$(pwd)/.cargo/
-      - cargo install cargo-deny
-      - cargo deny check licenses
+      - make check-licenses
     when:
       - event: pull_request
       - event: [push, tag, manual]
         branch: main
+
+  - name: checksum
+    image: *rust
+    commands:
+      - make checksum
+    when:
+      - event: tag
 
   - name: publish-distroless
     image: *buildx_plugin
@@ -103,3 +109,14 @@ steps:
     when:
       event: [push, tag, manual]
       branch: main
+
+  - name: publish-release
+    image: woodpeckerci/plugin-release:0.1.0
+    settings:
+      files:
+        - 'dist/*'
+      api_key:
+        from_secret: github_password
+      title: ${CI_COMMIT_TAG##v}
+    when:
+      - event: tag

--- a/Dockerfile.distroless.multiarch
+++ b/Dockerfile.distroless.multiarch
@@ -3,6 +3,6 @@ FROM gcr.io/distroless/static-debian12:nonroot
 LABEL org.opencontainers.image.source https://github.com/windsource/picus
 
 ARG TARGETOS TARGETARCH
-COPY target/dist/picus-${TARGETOS}-${TARGETARCH} /usr/local/bin/picus
+COPY dist/picus-${TARGETOS}-${TARGETARCH} /usr/local/bin/picus
 
 CMD ["/usr/local/bin/picus"]

--- a/Dockerfile.multiarch
+++ b/Dockerfile.multiarch
@@ -9,6 +9,6 @@ RUN groupadd -g 999 appuser && \
 USER appuser
 
 ARG TARGETOS TARGETARCH
-COPY target/dist/picus-${TARGETOS}-${TARGETARCH} /usr/local/bin/picus
+COPY dist/picus-${TARGETOS}-${TARGETARCH} /usr/local/bin/picus
 
 CMD ["/usr/local/bin/picus"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,85 @@
+VENDOR_DIR ?= vendor
+
+CONFIG = .cargo/config.toml
+
+TARGET_AMD64 ?= x86_64-unknown-linux-musl
+TARGET_ARM64 ?= aarch64-unknown-linux-musl
+
+# Determine the host architecture
+ARCH := $(shell uname -m)
+
+# Translate the output of uname -m to either amd64 or arm64
+ifeq ($(ARCH),x86_64)
+  ARCH := amd64
+  DEFAULT_TARGET := $(TARGET_AMD64)
+else ifeq ($(ARCH),amd64)
+  ARCH := amd64
+  DEFAULT_TARGET := $(TARGET_AMD64)
+else ifeq ($(ARCH),aarch64)
+  ARCH := arm64
+  DEFAULT_TARGET := $(TARGET_ARM64)
+else ifeq ($(ARCH),arm64)
+  ARCH := arm64
+  DEFAULT_TARGET := $(TARGET_ARM64)
+else
+  $(error Unsupported architecture: $(ARCH))
+endif
+
+# In CI builds we cannot write to the home directory
+ifdef CI
+  CARGO_HOME := $(shell pwd)/.cargo
+  export CARGO_HOME
+endif
+
+ifdef CI_COMMIT_TAG
+  # remove the leading 'v' from the tag
+  VERSION = $(shell expr substr $(CI_COMMIT_TAG) 2 100)
+  SOURCE_ARCHIVE = dist/picus-vendored-source-$(VERSION).tar.gz
+  SOURCE_ARCHIVE_BASE = picus-$(VERSION)
+else
+  SOURCE_ARCHIVE = dist/picus-vendored-source.tar.gz
+  SOURCE_ARCHIVE_BASE = picus
+endif
+
+all: test build-amd64 build-arm64 checksum
+
+test:
+	cargo test --target $(DEFAULT_TARGET)
+
+build:
+	cargo build --target $(DEFAULT_TARGET)
+
+# Vendor sources and create source archive
+vendor: Cargo.toml dist
+	cargo vendor $(VENDOR_DIR)
+	@if ! grep vendored-sources $(CONFIG); then \
+	  echo '\n[source.crates-io]\nreplace-with = "vendored-sources"\n\n[source.vendored-sources]\ndirectory = "$(VENDOR_DIR)"' >> $(CONFIG); \
+	fi
+	# Note: The order is important in the next line. --exclude only affects items mentioned after it.
+	#       So we can include .cargo/config.toml while excluding the rest of the folder.
+	tar -czf $(SOURCE_ARCHIVE) --transform 's,^,$(SOURCE_ARCHIVE_BASE)/,' .cargo/config.toml --exclude=.cargo --exclude=target --exclude=dist --exclude=.git .
+
+build-amd64: dist
+	cargo build --release --target $(TARGET_AMD64)
+	cp target/$(TARGET_AMD64)/release/picus dist/picus-linux-amd64
+
+build-arm64: dist
+	cargo build --release --target $(TARGET_ARM64)
+	cp target/$(TARGET_ARM64)/release/picus dist/picus-linux-arm64
+
+checksum: dist
+	cd dist; sha256sum * > sha256sum.txt
+
+dist:
+	mkdir -p dist
+
+check-licenses:
+	cargo install cargo-deny
+	cargo deny check licenses
+
+clean:
+	rm -rf target
+	rm -rf $(VENDOR_DIR)
+	# Revert changes for vendored sources
+	git checkout -- $(CONFIG)
+	rm -rf dist


### PR DESCRIPTION
This PR uses a makefile to keep all build instructions which is then used also in CI build. In addition a release also publishes build artifacts like binary versions of Picus for amd64 and arm64.