### PR TITLE
Updates README to be compatible with woodpecker v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ services:
       - PICUS_WOODPECKER_AGENT_ID=1
       - PICUS_AGENT_WOODPECKER_SERVER=woodpecker.example.com:443
       - PICUS_AGENT_WOODPECKER_AGENT_SECRET=<...>
-      - PICUS_AGENT_WOODPECKER_FILTER_LABELS=platform=linux/amd64,backend=docker,repo=*,org-ci=*
+      - PICUS_AGENT_WOODPECKER_FILTER_LABELS=platform=linux/amd64,backend=docker,repo=*,org-id=*
       - PICUS_AGENT_WOODPECKER_BACKEND=docker
       - PICUS_PROVIDER_TYPE=hcloud
       - PICUS_HCLOUD_TOKEN=<...>
@@ -48,7 +48,7 @@ Name | Description | Default
 `PICUS_WOODPECKER_SERVER` | URL to the Woodpecker host like `https://woodpecker.example.com` | -
 `PICUS_WOODPECKER_TOKEN` | Personal token to Woodpecker | -
 `PICUS_WOODPECKER_AGENT_ID` | ID of the agent as provided by the Woodpecker UI in 'Settings' -> 'Agents' when editing a specific agent | -
-`PICUS_AGENT_WOODPECKER_FILTER_LABELS` | Filter labels according to [woodpecker doc](https://woodpecker-ci.org/docs/administration/agent-config#woodpecker_filter_labels) that Picus will use to check if an agent needs to be started. The default labels of an agent `platform`, `backend` and `repo` must be added as well such that Picus can use them. Example: `platform=linux/amd64,backend=docker,repo=*`.| -  
+`PICUS_AGENT_WOODPECKER_FILTER_LABELS` | Filter labels according to [woodpecker doc](https://woodpecker-ci.org/docs/administration/agent-config#woodpecker_filter_labels) that Picus will use to check if an agent needs to be started. The default labels of an agent `platform`, `backend`, `repo` and `org-id` must be added as well such that Picus can use them. Example: `platform=linux/amd64,backend=docker,repo=*,org-id=*`.| -  
 `PICUS_POLL_INTERVAL` | Interval in which Picus will poll the Woodpecker API `/api/queue/info`.  For format see [go_parse_duration](https://docs.rs/go-parse-duration/latest/go_parse_duration/). | 10s
 `PICUS_MAX_IDLE_TIME` | Duration to wait after the last running job before shutting down or stopping an agent. For format see [go_parse_duration](https://docs.rs/go-parse-duration/latest/go_parse_duration/). | 30m
 `PICUS_PROVIDER_TYPE` | Type of cloud provider to use. Valid values are `hcloud` and `aws` | -

--- a/aws_agent_example.yml
+++ b/aws_agent_example.yml
@@ -32,7 +32,7 @@ Parameters:
   WoodpeckerFilterLabels:
     Description: Labels for agent to pick pipeline
     Type: String
-    Default: 'platform=linux/amd64,backend=docker,repo=*'
+    Default: 'platform=linux/amd64,backend=docker,repo=*,org-id=*'
 Mappings: 
   RegionMap: 
     eu-west-1:


### PR DESCRIPTION
This commit adapts the documentation found in the README to be compatible with woodpecker v3 which introduced the `org-ci` label by default.

Ideas from discussion in #25